### PR TITLE
Remove centos7 build from CI.

### DIFF
--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22", "centos7"]
+        image: ["alma9", "ubuntu22"]
       fail-fast: false
 
     steps:

--- a/.github/workflows/key4hep.yml
+++ b/.github/workflows/key4hep.yml
@@ -7,7 +7,12 @@ jobs:
     strategy:
       matrix:
         build_type: ["release", "nightly"]
-        image: ["alma9", "ubuntu22"]
+        image: ["alma9"]
+        include:
+          - build_type: nightly
+            image: ubuntu24
+          - build_type: release
+            image: ubuntu22
       fail-fast: false
 
     steps:


### PR DESCRIPTION
We no longer have centos7 builds.
Remove centos7 CI jobs --- they were just failing.


BEGINRELEASENOTES
- Remove (obsolete) centos7 builds from CI.
ENDRELEASENOTES