### PR TITLE
Fix a number of compilation warnings:

### DIFF
--- a/src/geomlib/TRKTrack.h
+++ b/src/geomlib/TRKTrack.h
@@ -34,7 +34,7 @@ public:
    // Ctors and Dtor
    TRKTrack(Double_t chg, TVector3 x, TVector3 p);
    TRKTrack(const TRKTrack&);
-   TRKTrack& operator=(const TRKTrack&) = default ;
+   TRKTrack& operator=(const TRKTrack&) = delete ;
 
    virtual ~TRKTrack() {}
 

--- a/src/geomlib/TRungeKuttaTrack.h
+++ b/src/geomlib/TRungeKuttaTrack.h
@@ -70,7 +70,7 @@ public:
    void SetFromTrack(THelicalTrack& heltrack);
 
    // Utility methods
-   virtual void MoveTo(const TVector3 &globalPivot, 
+    virtual void MoveTo(const TVector3 &globalPivot, 
                              Double_t &step,     
 		                     TMatrixD  *FPtr = 0,    
 		                     TMatrixD  *F12Ptr = 0,    
@@ -79,6 +79,14 @@ public:
    virtual void MoveTo(const TVector3    &globalPivot, 
                              Double_t    &step,     
 		                     TKalMatrix  &FPtr);
+
+   // Do not allow calls to the base class method.
+   virtual void MoveTo(const TVector3 &,
+                             Double_t &,
+                             TMatrixD *,
+                             TMatrixD *,
+                       Bool_t   )
+   { std::abort(); }
 
    virtual TVector3 CalcXAt   (Double_t h) const;
    virtual TMatrixD CalcDxDa  (Double_t h) const;

--- a/src/geomlib/TRungeKuttaTrack.h
+++ b/src/geomlib/TRungeKuttaTrack.h
@@ -70,7 +70,7 @@ public:
    void SetFromTrack(THelicalTrack& heltrack);
 
    // Utility methods
-    virtual void MoveTo(const TVector3 &globalPivot, 
+   virtual void MoveTo(const TVector3 &globalPivot,
                              Double_t &step,     
 		                     TMatrixD  *FPtr = 0,    
 		                     TMatrixD  *F12Ptr = 0,    

--- a/src/geomlib/TTube.cxx
+++ b/src/geomlib/TTube.cxx
@@ -117,6 +117,7 @@ Int_t TTube::CalcXingPointWith(const TVTrack  &hel,
             }
          }
          if (IsOnBarrel(xx)) return 1;
+         [[fallthrough]];
       default: // track hitting end cap part
          if (TMath::Abs(tnl) < 0.1) {
             return 0;

--- a/src/kallib/TKalMatrix.h
+++ b/src/kallib/TKalMatrix.h
@@ -50,6 +50,9 @@ public:
 
    TKalMatrix& operator= (const TKalMatrix &orig) = default;
 
+   TKalMatrix(TKalMatrix&&) = delete;
+   TKalMatrix& operator= (TKalMatrix&&) = delete;
+
    virtual ~TKalMatrix() {}
 
   // virtual void  DebugPrint() const { DebugPrint( "", 5 , std::cerr ) ; }

--- a/src/kallib/TKalMatrix.h
+++ b/src/kallib/TKalMatrix.h
@@ -48,6 +48,8 @@ public:
 
    TKalMatrix(const TRotation &r);
 
+   TKalMatrix& operator= (const TKalMatrix &orig) = default;
+
    virtual ~TKalMatrix() {}
 
   // virtual void  DebugPrint() const { DebugPrint( "", 5 , std::cerr ) ; }

--- a/src/kallib/TKalMatrix.h
+++ b/src/kallib/TKalMatrix.h
@@ -50,8 +50,8 @@ public:
 
    TKalMatrix& operator= (const TKalMatrix &orig) = default;
 
-   TKalMatrix(TKalMatrix&&) = delete;
-   TKalMatrix& operator= (TKalMatrix&&) = delete;
+   TKalMatrix(TKalMatrix&&) = default;
+   TKalMatrix& operator= (TKalMatrix&&) = default;
 
    virtual ~TKalMatrix() {}
 

--- a/src/kallib/TKalMatrix.h
+++ b/src/kallib/TKalMatrix.h
@@ -48,10 +48,10 @@ public:
 
    TKalMatrix(const TRotation &r);
 
-   TKalMatrix& operator= (const TKalMatrix &orig) = default;
+   TKalMatrix& operator=(const TKalMatrix &orig) = default;
 
    TKalMatrix(TKalMatrix&&) = default;
-   TKalMatrix& operator= (TKalMatrix&&) = default;
+   TKalMatrix& operator=(TKalMatrix&&) = default;
 
    virtual ~TKalMatrix() {}
 

--- a/src/kaltracklib/TKalTrackState.h
+++ b/src/kaltracklib/TKalTrackState.h
@@ -60,6 +60,10 @@ public:
                            TKalMatrix	&F, 
                            TKalMatrix &Q) const;
 
+  virtual void  DebugPrint(std::ostream& os, Option_t *, Int_t  ) const
+  { DebugPrint(os); }
+  virtual void  DebugPrint(Option_t *, Int_t  ) const
+  { DebugPrint(); }
   void         DebugPrint() const ;
   void         DebugPrint( std::ostream& os ) const;
 

--- a/src/kaltracklib/TTrackFrame.h
+++ b/src/kaltracklib/TTrackFrame.h
@@ -39,7 +39,7 @@ public:
    //rotation matrix.
    TTrackFrame(const TTrackFrame &lastFrame, const TVector3 &v, const TVector3 &b);
 
-   //TTrackFrame& operator=( const TTrackFrame& frame );
+   TTrackFrame& operator=( const TTrackFrame& frame ) = default;
 
    virtual ~TTrackFrame() {}
 


### PR DESCRIPTION
 - The TEveTrackPropagator base of TRKTrack does not have a public copy ctor. So we should delete the copy ctor in the derived class, not default it.
 - Similarly, give TTrackFrame and TKalMatrix a explicitly-defaulted assignment operators, since they have copy constructors.
 - Explicitly mark fallthrough in a switch statement.
 - Avoid warnings about hiding virtual functions from a base class.



BEGINRELEASENOTES
- Fix a number of warnings seen with recent compilers.
ENDRELEASENOTES