### PR TITLE
Bump the minimum version of CMake to 3.10, to be able to compile with CMake 4.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,7 @@
 # cmake file for building KalFit libraries
 # @author Jan Engels, DESY
 # @author F. Gaede, DESY
-CMAKE_MINIMUM_REQUIRED( VERSION 2.6 FATAL_ERROR )
+CMAKE_MINIMUM_REQUIRED( VERSION 3.10 FATAL_ERROR )
 ########################################################
 
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -64,5 +64,9 @@ ADD_SUBDIRECTORY( ./examples/kaltest )
 DISPLAY_STD_VARIABLES()
 
 # generate and install following configuration files
-GENERATE_PACKAGE_CONFIGURATION_FILES( KalTestConfig.cmake KalTestConfigVersion.cmake KalTestLibDeps.cmake )
-
+# Modern CMake no longer generates the legacy dependency file used by this
+# package-config template.
+GENERATE_PACKAGE_CONFIGURATION_FILES( KalTestConfig.cmake KalTestConfigVersion.cmake )
+FILE( WRITE "${PROJECT_BINARY_DIR}/KalTestLibDeps.cmake"
+      "# KalTest shared-library dependency information is resolved at runtime.\n" )
+INSTALL( FILES "${PROJECT_BINARY_DIR}/KalTestLibDeps.cmake" DESTINATION lib/cmake )


### PR DESCRIPTION
BEGINRELEASENOTES
- Bump the minimum version of CMake to 3.10, to be able to compile with CMake 4.0

ENDRELEASENOTES
  
See https://cmake.org/cmake/help/latest/release/4.0.html#deprecated-and-removed-features