### PR TITLE
Fix some clang warnings.

### DIFF
--- a/src/geomlib/THelicalTrack.h
+++ b/src/geomlib/THelicalTrack.h
@@ -69,6 +69,9 @@ public:
                        Double_t     b,
                  const TTrackFrame &frame);
 
+   THelicalTrack(const THelicalTrack&) = default;
+   THelicalTrack& operator=(const THelicalTrack&) = default;
+
    virtual ~THelicalTrack() {}
 
    // Utility methods

--- a/src/geomlib/THelicalTrack.h
+++ b/src/geomlib/THelicalTrack.h
@@ -71,6 +71,8 @@ public:
 
    THelicalTrack(const THelicalTrack&) = default;
    THelicalTrack& operator=(const THelicalTrack&) = default;
+   THelicalTrack(THelicalTrack&&) = default;
+   THelicalTrack& operator=(THelicalTrack&&) = default;
 
    virtual ~THelicalTrack() {}
 

--- a/src/geomlib/TVTrack.h
+++ b/src/geomlib/TVTrack.h
@@ -62,6 +62,9 @@ public:
                  Double_t     b,
            const TTrackFrame &f);
 
+   TVTrack(const TVTrack&) = default;
+   TVTrack& operator=(const TVTrack&) = default;
+
    virtual ~TVTrack() {}
 
    // Utility methods

--- a/src/geomlib/TVTrack.h
+++ b/src/geomlib/TVTrack.h
@@ -64,6 +64,8 @@ public:
 
    TVTrack(const TVTrack&) = default;
    TVTrack& operator=(const TVTrack&) = default;
+   TVTrack(TVTrack&&) = default;
+   TVTrack& operator=(TVTrack&&) = default;
 
    virtual ~TVTrack() {}
 

--- a/src/kaltracklib/TTrackFrame.h
+++ b/src/kaltracklib/TTrackFrame.h
@@ -35,11 +35,14 @@ public:
    //Copy constructor
    TTrackFrame(const TTrackFrame &orig);
 
+   TTrackFrame(TTrackFrame&&) = default;
+   TTrackFrame& operator=(TTrackFrame&&) = default;
+
    //Build frame by last frame, shift vector and B field. The B field determines local
    //rotation matrix.
    TTrackFrame(const TTrackFrame &lastFrame, const TVector3 &v, const TVector3 &b);
 
-   //TTrackFrame& operator=( const TTrackFrame& frame );
+   TTrackFrame& operator=(const TTrackFrame& frame) = default;
 
    virtual ~TTrackFrame() {}
 


### PR DESCRIPTION
Explicitly request default copy ctor/assignment in THelicalTrack/TVTrack. Since these have user-defined dtors, they are otherwise deprecated. Fixes warnings seen in building k4Reco with clang.

BEGINRELEASENOTES
- Fix warnings seen when building k4Reco with clang.
ENDRELEASENOTES