### PR TITLE
Add LANGUAGES CXX to project()

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,7 @@ CMAKE_MINIMUM_REQUIRED( VERSION 2.6 FATAL_ERROR )
 
 
 # project name
-PROJECT( KalTest )
+PROJECT( KalTest LANGUAGES CXX )
 
 
 # project version


### PR DESCRIPTION
BEGINRELEASENOTES
- Add an explicit CXX language specification to the CMake project() call, not to look for a C compiler.

ENDRELEASENOTES
